### PR TITLE
Add support for Pyxis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This code was inspired by the javascript version available here https://github.c
 
 ## 0. Requirements
 Linux, Python (>=2.7 or >=3.5) and  bluepy (https://github.com/lucapinello/bluepy)
-(pypygatt >=4.0.3 is also partially supported https://github.com/peplin/pygatt)
+(pygatt >=4.0.3 is also partially supported https://github.com/peplin/pygatt;
+ Pyxis not supported under pygatt)
 
 This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (stretch)
 
@@ -32,7 +33,11 @@ This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (st
 
     scale.disconnect()
 
-```    
+``` 
+API change:
+Pyacaia now calls bluepy's Peripheral.waitForNotifications() internally.
+If your application uses waitForNotications() directly, it should be removed.
+---
 
 By default the backend used is blupy, but also pygatt is supported. In that case use:
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (st
     scale.disconnect()
 
 ``` 
+
 API change:
-Pyacaia now calls bluepy's Peripheral.waitForNotifications() internally.
-If your application uses waitForNotications() directly, it should be removed.
----
+
+Pyacaia now calls bluepy's Peripheral.waitForNotifications() internally.  If your application uses waitForNotications() directly, it should be removed.
 
 By default the backend used is blupy, but also pygatt is supported. In that case use:
 

--- a/pyacaia/__init__.py
+++ b/pyacaia/__init__.py
@@ -345,9 +345,7 @@ class AcaiaScale(object):
                 self.weight=msg.value
                 logging.debug('weight: ' + str(msg.value)+' '+str(time.time()))
             else:
-                logging.debug('non-weight response')
-                logging.debug(msg.value)
-                pass
+                logging.debug('non-weight response: '+str(msg.msgType))
 
 
     def connect(self):
@@ -488,8 +486,8 @@ class AcaiaScale(object):
 
             logging.debug('Heartbeat success')
             return True
-        except:
-            logging.debug('Heartbeat failed')
+        except Exception as e:
+            logging.debug('Heartbeat failed '+str(e))
 
 
     def tare(self):


### PR DESCRIPTION
This PR adds support for the Pyxis scale, which has different UUIDs and splits the notification UUID from the command UUID.  Pyxis support was only added for Bluepy.  Perhaps the most potentially controversial commit in this PR is commit 9f5c6e1, in which the heartbeat mechanism is changed.  Bluepy requires that waitForNotifications() be called in order to get the weight notifications in real time.  Since the heartbeat occurs in its own thread, if the application calls waitForNotifications(), there is collisions in some of the code that is not reentrant.  So heartbeat is changed so that waitForNotifications() replaces the Timer.  Unfortunately, existing applications that call waitForNotificaitons() directly will break, so a note has been added to README.md.

Further PRs will add support for some of the non-weight functions and notifications.