### PR TITLE
Add timer and settings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Linux, Python (>=2.7 or >=3.5) and  bluepy (https://github.com/lucapinello/bluep
 (pygatt >=4.0.3 is also partially supported https://github.com/peplin/pygatt;
  Pyxis not supported under pygatt)
 
-This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (stretch)
+This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (stretch) and on Ubuntu Linux 20.04, and with the Lunar and Pyxis scales.
 
 ## 1. Install with:
 
@@ -26,20 +26,54 @@ This package has been tested on a RasperryPI ZeroW with Raspbian GNU/Linux 9 (st
     # Or if you know the address use:
     # scale.connect()
     
+    # battery value in percent
+    print(scale.battery)
+
+    # scale units is 'grams' or 'ounces'
+    print(scale.units)
+
+    # minutes of idle before auto-off
+    print(scale.auto_off)
+
+    # will the scale beep when a button is pressed?
+    if scale.beep_on:
+	print('It beeps!')
+    else:
+	print('It is silent!')
+
+    # is the timer running?
+    if scale.timer_running:
+	print('timer is running')
+	# elapsed time is in seconds, if timer is paused
+	# the value will be the displayed time
+	# Due to bluetooth transit time, the value
+	# may be slightly different than displayed
+        print('elapsed time:',scale.get_elapsed_time())
+
+    # Tare the scale
+    scale.tare()
+
+    # Control the timer
+    scale.startTimer()
+    time.sleep(2)
+    scale.stopTimer()
+    scale.resetTimer()
+
     #read and print the weight every 0.5 sec for 5 sec 
     for i in range(10):
         print scale.weight # this is the property we can use to read the weigth in realtime
         time.sleep(0.5)
+	# check if the scale is still connected, perhaps it was turned off?
+	if not scale.connected:
+	    break
 
     scale.disconnect()
 
 ``` 
 
-API change:
+Pyacaia now calls bluepy's Peripheral.waitForNotifications() internally.  If your application uses waitForNotications() directly with 0.3.0 or earlier, that call should be removed.
 
-Pyacaia now calls bluepy's Peripheral.waitForNotifications() internally.  If your application uses waitForNotications() directly, it should be removed.
-
-By default the backend used is blupy, but also pygatt is supported. In that case use:
+By default the backend used is bluepy, but also pygatt is supported. In that case use:
 
    scale=AcaiaScale(mac='00:1C:97:17:FD:97',backend='pygatt')
    

--- a/pyacaia/__init__.py
+++ b/pyacaia/__init__.py
@@ -598,6 +598,7 @@ class AcaiaScale(object):
             return True
         except Exception as e:
             logging.debug('Heartbeat failed '+str(e))
+            return False
 
 
     def tare(self):
@@ -640,11 +641,12 @@ class AcaiaScale(object):
         if self.device:
 
             if self.backend=='pygatt':
-
                 self.device.disconnect()
                 self.adapter.stop()
 
             elif self.backend=='bluepy':
+                self.set_interval_thread.stop()
+                time.sleep(0.2)
                 self.device.disconnect()
         self.set_interval_thread.stop()
 

--- a/pyacaia/__init__.py
+++ b/pyacaia/__init__.py
@@ -237,6 +237,18 @@ def encodeTare():
     payload = [0];
     return encode(4, payload)
 
+def encodeStartTimer():
+    payload = [0,0]
+    return encode(13, payload)
+
+def encodeStopTimer():
+    payload = [0,2]
+    return encode(13, payload)
+
+def encodeResetTimer():
+    payload = [0,1]
+    return encode(13, payload)
+
 class setInterval(Thread):
 
     def __init__(self,func,interval):
@@ -522,6 +534,29 @@ class AcaiaScale(object):
 
         return True
 
+    def startTimer(self):
+        if not self.connected:
+            return False
+        if self.backend=='bluepy':
+            self.char.write( encodeStartTimer(), withResponse=False)
+        elif self.backend=='pygatt':
+            self.device.char_write(self.char_uuid,encodeStartTimer(),wait_for_response=False)
+
+    def stopTimer(self):
+        if not self.connected:
+            return False
+        if self.backend=='bluepy':
+            self.char.write( encodeStopTimer(), withResponse=False)
+        elif self.backend=='pygatt':
+            self.device.char_write(self.char_uuid,encodeStopTimer(),wait_for_response=False)
+
+    def resetTimer(self):
+        if not self.connected:
+            return False
+        if self.backend=='bluepy':
+            self.char.write( encodeResetTimer(), withResponse=False)
+        elif self.backend=='pygatt':
+            self.device.char_write(self.char_uuid,encodeResetTimer(),wait_for_response=False)
 
     def disconnect(self):
 

--- a/pyacaia/__init__.py
+++ b/pyacaia/__init__.py
@@ -732,8 +732,6 @@ class AcaiaScale(object):
                 self.adapter.stop()
 
             elif self.backend=='bluepy':
-                self.set_interval_thread.stop()
-                time.sleep(0.2)
                 self.device.disconnect()
         self.set_interval_thread.stop()
 


### PR DESCRIPTION
This PR adds support for reading and writing the scale timer, and for reading (some) of the settings.   To support new API that communicates with the scale, a new CommandQUeue is added so that all scale communication is done in the heartbeat thread to avoid clashes.  Some effort was made to allow for nice disconnects if the scale is turned off or moved out of range.

See the README.md example for the expanded API